### PR TITLE
Naming the define() AMD module

### DIFF
--- a/src/angularAMD.js
+++ b/src/angularAMD.js
@@ -4,7 +4,7 @@
  License: MIT
 */
 
-define(function () {
+define('angularAMD', function () {
     'use strict';
     var bootstrapped = false,
 


### PR DESCRIPTION
This solves the error related to mismatched anonymous define() module